### PR TITLE
external-data-checker: only submit PRs for important updates

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "require-important-update": true
+}

--- a/org.kde.kwave.json
+++ b/org.kde.kwave.json
@@ -94,6 +94,7 @@
                     "url": "https://download.kde.org/stable/release-service/25.12.0/src/kwave-25.12.0.tar.xz",
                     "sha256": "c65bbc823f943249ed05ded7be5b62b7f75a6bcf697229f733332de0fc7c7fa8",
                     "x-checker-data": {
+                        "is-main-source": true,
                         "type": "anitya",
                         "project-id": 8763,
                         "stable-only": true,


### PR DESCRIPTION
most of the shared-modules updates don't affect Kwave