### PR TITLE
remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Dependabot was only used for the libmad shared-module, which gets very few updates, so nearly all of the PRs were just noise updating other shared-modules. The shared-modules can be updated manually when Kwave gets a new release.